### PR TITLE
Fix voice delete

### DIFF
--- a/src/HonzaBotner.Discord.Services/VoiceManager.cs
+++ b/src/HonzaBotner.Discord.Services/VoiceManager.cs
@@ -88,29 +88,33 @@ namespace HonzaBotner.Discord.Services
                     model.Userlimit = limit;
                 });
 
-                if (member.VoiceState.Channel != null)
+                try
                 {
-                    await member.PlaceInAsync(newChannel);
-                }
-                else
-                {
-                    // Placing the member in the channel failed, so remove it after some time.
-                    var _ = Task.Run(async () =>
+                    if (member.VoiceState.Channel != null)
                     {
-                        await Task.Delay(1000 * _voiceConfig.RemoveAfterCommandInSeconds);
-                        await DeleteUnusedVoiceChannelAsync(newChannel);
-                    });
+                        await member.PlaceInAsync(newChannel);
+                    }
                 }
+                catch
+                {
+                    // User disconnected while we were placing them.
+                }
+
+                // Placing the member in the channel failed, so remove it after some time.
+                var _ = Task.Run(async () =>
+                {
+                    await Task.Delay(1000 * _voiceConfig.RemoveAfterCommandInSeconds);
+                    await DeleteUnusedVoiceChannelAsync(newChannel);
+                });
             }
             catch (Exception e)
             {
-                _logger.LogWarning(e , "Creating voice channel failed.");
+                _logger.LogError(e, "Creating voice channel failed.");
             }
         }
 
         public async Task<bool> EditVoiceChannelAsync(DiscordMember member, string? newName = null, int? limit = 0)
         {
-
             if (member.VoiceState.Channel == null)
             {
                 return false;

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -55,9 +55,11 @@ namespace HonzaBotner.Discord
             return Task.CompletedTask;
         }
 
-        private async Task Client_GuildAvailable(DiscordClient sender, GuildCreateEventArgs e)
+        private Task Client_GuildAvailable(DiscordClient sender, GuildCreateEventArgs e)
         {
             sender.Logger.LogInformation($"Guild available: {e.Guild.Name}");
+            
+            return Task.CompletedTask;
         }
 
         private async Task Client_GuildDownloadCompleted(DiscordClient sender, GuildDownloadCompletedEventArgs e)

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -55,9 +55,10 @@ namespace HonzaBotner.Discord
             return Task.CompletedTask;
         }
 
-        private async Task Client_GuildAvailable(DiscordClient sender, GuildCreateEventArgs e)
+        private Task Client_GuildAvailable(DiscordClient sender, GuildCreateEventArgs e)
         {
             sender.Logger.LogInformation($"Guild available: {e.Guild.Name}");
+            return Task.CompletedTask;
         }
 
         private async Task Client_GuildDownloadCompleted(DiscordClient sender, GuildDownloadCompletedEventArgs e)

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -38,6 +38,7 @@ namespace HonzaBotner.Discord
             Client.ClientErrored += Client_ClientError;
             Client.MessageReactionAdded += Client_MessageReactionAdded;
             Client.MessageReactionRemoved += Client_MessageReactionRemoved;
+            Client.GuildDownloadCompleted += Client_GuildDownloadCompleted;
 
             Commands.CommandExecuted += Commands_CommandExecuted;
             Commands.CommandErrored += Commands_CommandErrored;
@@ -57,7 +58,13 @@ namespace HonzaBotner.Discord
         private async Task Client_GuildAvailable(DiscordClient sender, GuildCreateEventArgs e)
         {
             sender.Logger.LogInformation($"Guild available: {e.Guild.Name}");
+        }
 
+        private async Task Client_GuildDownloadCompleted(DiscordClient sender, GuildDownloadCompletedEventArgs e)
+        {
+            sender.Logger.LogInformation($"Guild download completed.");
+
+            // Run managers.
             await _voiceManager.Init();
         }
 


### PR DESCRIPTION
I have discovered an error raised while users that were in the channel disconnected and we were trying to place him in the cloned channel. That might have terminated task runs.

Also, I have used better discord app starting event for initiating managers, after all the guilds connected (we have only one) downloaded their data, ergo. no nulls or empty collections.  