### PR TITLE
Add Buttons to verification messages

### DIFF
--- a/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
@@ -244,22 +244,17 @@ namespace HonzaBotner.Discord.Services.Commands
                     throw new ArgumentOutOfRangeException($"Couldn't find message with link: {url}");
                 }
 
-                DiscordEmoji reactEmoji = DiscordEmoji.FromName(ctx.Client, ":+1:");
                 try
                 {
                     await _buttonManager.RemoveButtonsFromMessage(message);
                 }
-                catch (Exception exception)
+                catch (UnauthorizedException)
                 {
-                    if (exception is not UnauthorizedException)
-                    {
-                        throw;
-                    }
-
-                    await ctx.RespondAsync("Chyba: Změny povoleny jen na zprávách odeslaných tímto botem");
-                    reactEmoji = DiscordEmoji.FromName(ctx.Client, ":-1:");
+                    await ctx.RespondAsync("Chyba: Změny možné jen na zprávách odeslaných tímto botem");
+                    return;
                 }
 
+                DiscordEmoji reactEmoji = DiscordEmoji.FromName(ctx.Client, ":+1:");
                 await ctx.Message.CreateReactionAsync(reactEmoji);
             }
 
@@ -273,21 +268,17 @@ namespace HonzaBotner.Discord.Services.Commands
                     throw new ArgumentOutOfRangeException($"Couldn't find message with link: {url}");
                 }
 
-                DiscordEmoji reactEmoji = DiscordEmoji.FromName(ctx.Client, ":+1:");
                 try
                 {
                     await _buttonManager.SetupVerificationButtons(message);
                 }
-                catch (Exception exception)
+                catch (UnauthorizedException)
                 {
-                    if (exception is not UnauthorizedException)
-                    {
-                        throw;
-                    }
-
-                    await ctx.RespondAsync("Chyba: Změny povoleny jen na zprávách odeslaných tímto botem");
-                    reactEmoji = DiscordEmoji.FromName(ctx.Client, ":-1:");
+                    await ctx.RespondAsync("Chyba: Změny možné jen na zprávách odeslaných tímto botem");
+                    return;
                 }
+
+                DiscordEmoji reactEmoji = DiscordEmoji.FromName(ctx.Client, ":+1:");
                 await ctx.Message.CreateReactionAsync(reactEmoji);
             }
         }

--- a/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
@@ -250,7 +250,7 @@ namespace HonzaBotner.Discord.Services.Commands
                 }
                 catch (UnauthorizedException)
                 {
-                    await ctx.RespondAsync("Chyba: Změny možné jen na zprávách odeslaných tímto botem");
+                    await ctx.RespondAsync("Error: You can only edit messages by this bot.");
                     return;
                 }
 
@@ -274,7 +274,7 @@ namespace HonzaBotner.Discord.Services.Commands
                 }
                 catch (UnauthorizedException)
                 {
-                    await ctx.RespondAsync("Chyba: Změny možné jen na zprávách odeslaných tímto botem");
+                    await ctx.RespondAsync("Error: You can only edit messages by this bot.");
                     return;
                 }
 

--- a/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
@@ -8,6 +8,7 @@ using DSharpPlus.EventArgs;
 using DSharpPlus.Interactivity;
 using DSharpPlus.Interactivity.Extensions;
 using HonzaBotner.Discord.Extensions;
+using HonzaBotner.Discord.Managers;
 using HonzaBotner.Discord.Services.Attributes;
 using HonzaBotner.Services.Contract;
 using Microsoft.Extensions.Logging;
@@ -218,6 +219,51 @@ namespace HonzaBotner.Discord.Services.Commands
                 // TODO: Pretty print of associated bindings with message
                 await ctx.Message.RespondAsync($"TODO: {roles.Count}");
             }*/
+        }
+
+        [Group("buttons")]
+        [Description("Module used to edit button interactions on messages")]
+        [ModuleLifespan(ModuleLifespan.Transient)]
+        public class ButtonCommands : BaseCommandModule
+        {
+            private readonly IButtonManager _buttonManager;
+
+            public ButtonCommands(IButtonManager manager)
+            {
+                _buttonManager = manager;
+            }
+
+            [Description("Deletes all button interactions on the message")]
+            [Command("remove")]
+            public async Task RemoveButtons(CommandContext ctx, [Description("URL of the message")] string url)
+            {
+                DiscordMessage? message = await DiscordHelper.FindMessageFromLink(ctx.Guild, url);
+                if (message == null)
+                {
+                    throw new ArgumentOutOfRangeException($"Couldn't find message with link: {url}");
+                }
+
+                await _buttonManager.RemoveButtonsFromMessage(message);
+
+                DiscordEmoji thumbsUp = DiscordEmoji.FromName(ctx.Client, ":+1:");
+                await ctx.Message.CreateReactionAsync(thumbsUp);
+            }
+
+            [Description("Marks message as verification message")]
+            [Command("setup")]
+            public async Task SetupButtons(CommandContext ctx, [Description("URL of the message")] string url)
+            {
+                DiscordMessage? message = await DiscordHelper.FindMessageFromLink(ctx.Guild, url);
+                if (message == null)
+                {
+                    throw new ArgumentOutOfRangeException($"Couldn't find message with link: {url}");
+                }
+
+                await _buttonManager.SetupVerificationButtons(message);
+
+                DiscordEmoji thumbsUp = DiscordEmoji.FromName(ctx.Client, ":+1:");
+                await ctx.Message.CreateReactionAsync(thumbsUp);
+            }
         }
     }
 }

--- a/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/MessageCommands.cs
@@ -5,6 +5,7 @@ using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
 using DSharpPlus.Interactivity;
 using DSharpPlus.Interactivity.Extensions;
 using HonzaBotner.Discord.Extensions;
@@ -243,10 +244,23 @@ namespace HonzaBotner.Discord.Services.Commands
                     throw new ArgumentOutOfRangeException($"Couldn't find message with link: {url}");
                 }
 
-                await _buttonManager.RemoveButtonsFromMessage(message);
+                DiscordEmoji reactEmoji = DiscordEmoji.FromName(ctx.Client, ":+1:");
+                try
+                {
+                    await _buttonManager.RemoveButtonsFromMessage(message);
+                }
+                catch (Exception exception)
+                {
+                    if (exception is not UnauthorizedException)
+                    {
+                        throw;
+                    }
 
-                DiscordEmoji thumbsUp = DiscordEmoji.FromName(ctx.Client, ":+1:");
-                await ctx.Message.CreateReactionAsync(thumbsUp);
+                    await ctx.RespondAsync("Chyba: Změny povoleny jen na zprávách odeslaných tímto botem");
+                    reactEmoji = DiscordEmoji.FromName(ctx.Client, ":-1:");
+                }
+
+                await ctx.Message.CreateReactionAsync(reactEmoji);
             }
 
             [Description("Marks message as verification message")]
@@ -259,10 +273,22 @@ namespace HonzaBotner.Discord.Services.Commands
                     throw new ArgumentOutOfRangeException($"Couldn't find message with link: {url}");
                 }
 
-                await _buttonManager.SetupVerificationButtons(message);
+                DiscordEmoji reactEmoji = DiscordEmoji.FromName(ctx.Client, ":+1:");
+                try
+                {
+                    await _buttonManager.SetupVerificationButtons(message);
+                }
+                catch (Exception exception)
+                {
+                    if (exception is not UnauthorizedException)
+                    {
+                        throw;
+                    }
 
-                DiscordEmoji thumbsUp = DiscordEmoji.FromName(ctx.Client, ":+1:");
-                await ctx.Message.CreateReactionAsync(thumbsUp);
+                    await ctx.RespondAsync("Chyba: Změny povoleny jen na zprávách odeslaných tímto botem");
+                    reactEmoji = DiscordEmoji.FromName(ctx.Client, ":-1:");
+                }
+                await ctx.Message.CreateReactionAsync(reactEmoji);
             }
         }
     }

--- a/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
@@ -53,9 +53,10 @@ namespace HonzaBotner.Discord.Services.EventHandlers
                 string verificationLink = _urlProvider.GetAuthLink(user.Id, RolesPool.Auth);
                 builder.Content =
                     "Ahoj, ještě nejsi ověřený!\n" +
-                    $"1) Pro ověření ✅ a přidělení rolí dle UserMap klikni na odkaz: {verificationLink}\n" +
-                    "2) Následně znovu klikni na tlačítko 👑 pro přidání zaměstnaneckých rolí.";
-
+                    "1) Pro ověření ✅ a přidělení rolí dle UserMap klikni na tlačítko dole\n" +
+                    "2) Následně znovu klikni na tlačítko pro přidání 👑 zaměstnaneckých rolí.";
+                builder.AddComponents(new DiscordLinkButtonComponent(verificationLink, "Ověřit se!", false,
+                    new DiscordComponentEmoji("✅")));
                 await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
                     builder);
 
@@ -65,7 +66,9 @@ namespace HonzaBotner.Discord.Services.EventHandlers
             await _roleManager.RevokeRolesPoolAsync(eventArgs.User.Id, RolesPool.Staff);
 
             string link = _urlProvider.GetAuthLink(user.Id, RolesPool.Staff);
-            builder.Content = $"Ahoj, pro získání rolí zaměstnance klikni na: {link}";
+            builder.Content = "Ahoj, klikni pro ověření zaměstnaneckých rolí";
+            builder.AddComponents(new DiscordLinkButtonComponent(link, "Jsem zaměstnanec!", false,
+                new DiscordComponentEmoji("👑")));
             await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);
 
             return EventHandlerResult.Stop;

--- a/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
@@ -114,7 +114,7 @@ namespace HonzaBotner.Discord.Services.EventHandlers
             }
             else
             {
-                builder.Content = "Ahoj, klikni na tlačítko pro ověřená rolí zaměstnance!";
+                builder.Content = "Ahoj, klikni na tlačítko pro ověření rolí zaměstnance!";
                 builder.AddComponents(new DiscordLinkButtonComponent(link, "Ověřit role zaměstnance!",
                     false, new DiscordComponentEmoji("👑")));
             }

--- a/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
@@ -1,9 +1,9 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using HonzaBotner.Discord.EventHandler;
-using HonzaBotner.Discord.Services.Options;
 using HonzaBotner.Services.Contract;
 using HonzaBotner.Services.Contract.Dto;
 using Microsoft.Extensions.Logging;
@@ -11,34 +11,28 @@ using Microsoft.Extensions.Options;
 
 namespace HonzaBotner.Discord.Services.EventHandlers
 {
-    public class StaffVerificationEventHandler : IEventHandler<MessageReactionAddEventArgs>,
-        IEventHandler<MessageReactionRemoveEventArgs>
+    public class StaffVerificationEventHandler : IEventHandler<ComponentInteractionCreateEventArgs>
     {
         private readonly IUrlProvider _urlProvider;
-        private readonly CommonCommandOptions _config;
         private readonly DiscordRoleConfig _discordRoleConfig;
         private readonly IDiscordRoleManager _roleManager;
         private readonly ILogger<StaffVerificationEventHandler> _logger;
 
         public StaffVerificationEventHandler(IUrlProvider urlProvider,
-            IOptions<CommonCommandOptions> options,
             IOptions<DiscordRoleConfig> discordRoleConfig,
             IDiscordRoleManager roleManager,
             ILogger<StaffVerificationEventHandler> logger)
         {
             _urlProvider = urlProvider;
-            _config = options.Value;
             _discordRoleConfig = discordRoleConfig.Value;
             _roleManager = roleManager;
             _logger = logger;
         }
 
-        public async Task<EventHandlerResult> Handle(MessageReactionAddEventArgs eventArgs)
+        public async Task<EventHandlerResult> Handle(ComponentInteractionCreateEventArgs eventArgs)
         {
-            if (!(eventArgs.Message.Id == _config.VerificationMessageId
-                  && eventArgs.Message.ChannelId == _config.VerificationChannelId))
-                return EventHandlerResult.Continue;
-            if (!eventArgs.Emoji.Name.Equals(_config.StaffVerificationEmojiName)) return EventHandlerResult.Continue;
+            if (eventArgs.Id != "staff-verification") return EventHandlerResult.Continue;
+            await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
 
             DiscordUser user = eventArgs.User;
             DiscordMember member = eventArgs.Guild.Members[user.Id];
@@ -65,29 +59,12 @@ namespace HonzaBotner.Discord.Services.EventHandlers
                 return EventHandlerResult.Stop;
             }
 
+            await _roleManager.RevokeRolesPoolAsync(eventArgs.User.Id, RolesPool.Staff);
+
             string link = _urlProvider.GetAuthLink(user.Id, RolesPool.Staff);
             await channel.SendMessageAsync($"Ahoj, pro získání rolí zaměstnance klikni na: {link}");
 
             return EventHandlerResult.Stop;
-        }
-
-        public async Task<EventHandlerResult> Handle(MessageReactionRemoveEventArgs eventArgs)
-        {
-            if (!(eventArgs.Message.Id == _config.VerificationMessageId
-                  && eventArgs.Message.ChannelId == _config.VerificationChannelId))
-                return EventHandlerResult.Continue;
-            if (!eventArgs.Emoji.Name.Equals(_config.StaffVerificationEmojiName)) return EventHandlerResult.Continue;
-
-            bool revoked = await _roleManager.RevokeRolesPoolAsync(eventArgs.User.Id, RolesPool.Staff);
-            if (!revoked)
-            {
-                _logger.LogWarning("Ungranting roles for user {Username} (id {Id}) failed", eventArgs.User.Username,
-                    eventArgs.User.Id);
-                DiscordDmChannel channel = await eventArgs.Guild.Members[eventArgs.User.Id].CreateDmChannelAsync();
-                await channel.SendMessageAsync("Staff role se nepodařilo odebrat. Prosím, kontaktujte moderátory.");
-            }
-
-            return EventHandlerResult.Continue;
         }
     }
 }

--- a/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/StaffVerificationEventHandler.cs
@@ -101,7 +101,7 @@ namespace HonzaBotner.Discord.Services.EventHandlers
 
             string link = _urlProvider.GetAuthLink(user.Id, RolesPool.Staff);
 
-            if (isStaffAuthenticated)
+            if (isStaffAuthenticated && _buttonOptions.StaffRemoveRoleId is not null)
             {
                 builder.Content = "Ahoj, už jsi ověřený,\nChceš aktualizovat svoje role přes UserMap?";
                 builder.AddComponents(new DiscordComponent[]

--- a/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
@@ -37,7 +37,7 @@ namespace HonzaBotner.Discord.Services.EventHandlers
             DiscordUser user = eventArgs.User;
             DiscordMember member = eventArgs.Guild.Members[user.Id];
 
-            string link = _urlProvider.GetAuthLink(eventArgs.User.Id, RolesPool.Auth);
+            string link = _urlProvider.GetAuthLink(user.Id, RolesPool.Auth);
 
             // Check if the user is authenticated.
             bool isAuthenticated = false;

--- a/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
@@ -24,23 +24,21 @@ namespace HonzaBotner.Discord.Services.EventHandlers
             // https://discordapp.com/channels/366970031445377024/507515506073403402/686745124885364770
 
             if (eventArgs.Id != "user-verification") return EventHandlerResult.Continue;
-            await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
 
-            DiscordUser user = eventArgs.User;
-            DiscordDmChannel channel = await eventArgs.Guild.Members[user.Id].CreateDmChannelAsync();
+            DiscordInteractionResponseBuilder builder = new DiscordInteractionResponseBuilder().AsEphemeral(true);
 
-            string link = _urlProvider.GetAuthLink(user.Id, RolesPool.Auth);
+            string link = _urlProvider.GetAuthLink(eventArgs.User.Id, RolesPool.Auth);
 
-            if (await _authorizationService.IsUserVerified(user.Id))
+            if (await _authorizationService.IsUserVerified(eventArgs.User.Id))
             {
-                await channel.SendMessageAsync(
-                    $"Ahoj, už jsi ověřený.\nPro aktualizaci rolí dle UserMap klikni na odkaz: {link}");
+                builder.Content = $"Ahoj, už jsi ověřený.\nPro aktualizaci rolí dle UserMap klikni na odkaz: {link}";
             }
             else
             {
-                await channel.SendMessageAsync(
-                    $"Ahoj, pro ověření a přidělení rolí dle UserMap klikni na odkaz: {link}");
+                builder.Content = $"Ahoj, pro ověření a přidělení rolí dle UserMap klikni na odkaz: {link}";
             }
+
+            await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);
 
             return EventHandlerResult.Stop;
         }

--- a/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
@@ -1,36 +1,30 @@
 ﻿using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using HonzaBotner.Discord.EventHandler;
-using HonzaBotner.Discord.Services.Options;
 using HonzaBotner.Services.Contract;
 using HonzaBotner.Services.Contract.Dto;
-using Microsoft.Extensions.Options;
 
 namespace HonzaBotner.Discord.Services.EventHandlers
 {
-    public class VerificationEventHandler : IEventHandler<MessageReactionAddEventArgs>
+    public class VerificationEventHandler : IEventHandler<ComponentInteractionCreateEventArgs>
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly IUrlProvider _urlProvider;
-        private readonly CommonCommandOptions _config;
 
-        public VerificationEventHandler(IAuthorizationService authorizationService, IUrlProvider urlProvider,
-            IOptions<CommonCommandOptions> options)
+        public VerificationEventHandler(IAuthorizationService authorizationService, IUrlProvider urlProvider)
         {
             _authorizationService = authorizationService;
             _urlProvider = urlProvider;
-            _config = options.Value;
         }
 
-        public async Task<EventHandlerResult> Handle(MessageReactionAddEventArgs eventArgs)
+        public async Task<EventHandlerResult> Handle(ComponentInteractionCreateEventArgs eventArgs)
         {
             // https://discordapp.com/channels/366970031445377024/507515506073403402/686745124885364770
 
-            if (!(eventArgs.Message.Id == _config.VerificationMessageId
-                  && eventArgs.Message.ChannelId == _config.VerificationChannelId))
-                return EventHandlerResult.Continue;
-            if (!eventArgs.Emoji.Name.Equals(_config.VerificationEmojiName)) return EventHandlerResult.Continue;
+            if (eventArgs.Id != "user-verification") return EventHandlerResult.Continue;
+            await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
 
             DiscordUser user = eventArgs.User;
             DiscordDmChannel channel = await eventArgs.Guild.Members[user.Id].CreateDmChannelAsync();

--- a/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
@@ -3,8 +3,10 @@ using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using HonzaBotner.Discord.EventHandler;
+using HonzaBotner.Discord.Services.Options;
 using HonzaBotner.Services.Contract;
 using HonzaBotner.Services.Contract.Dto;
+using Microsoft.Extensions.Options;
 
 namespace HonzaBotner.Discord.Services.EventHandlers
 {
@@ -12,18 +14,20 @@ namespace HonzaBotner.Discord.Services.EventHandlers
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly IUrlProvider _urlProvider;
+        private readonly ButtonOptions _buttonOptions;
 
-        public VerificationEventHandler(IAuthorizationService authorizationService, IUrlProvider urlProvider)
+        public VerificationEventHandler(IAuthorizationService authorizationService, IUrlProvider urlProvider, IOptions<ButtonOptions> options)
         {
             _authorizationService = authorizationService;
             _urlProvider = urlProvider;
+            _buttonOptions = options.Value;
         }
 
         public async Task<EventHandlerResult> Handle(ComponentInteractionCreateEventArgs eventArgs)
         {
             // https://discordapp.com/channels/366970031445377024/507515506073403402/686745124885364770
 
-            if (eventArgs.Id != "user-verification") return EventHandlerResult.Continue;
+            if (eventArgs.Id != _buttonOptions.VerificationId) return EventHandlerResult.Continue;
 
             DiscordInteractionResponseBuilder builder = new DiscordInteractionResponseBuilder().AsEphemeral(true);
 

--- a/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/VerificationEventHandler.cs
@@ -31,11 +31,15 @@ namespace HonzaBotner.Discord.Services.EventHandlers
 
             if (await _authorizationService.IsUserVerified(eventArgs.User.Id))
             {
-                builder.Content = $"Ahoj, už jsi ověřený.\nPro aktualizaci rolí dle UserMap klikni na odkaz: {link}";
+                builder.Content = "Ahoj, už jsi ověřený.\nChceš aktualizovat role dle UserMap?";
+                builder.AddComponents(new DiscordLinkButtonComponent(link, "Aktualizovat role", false,
+                    new DiscordComponentEmoji("🔄")));
             }
             else
             {
-                builder.Content = $"Ahoj, pro ověření a přidělení rolí dle UserMap klikni na odkaz: {link}";
+                builder.Content = "Ahoj, pro ověření a přidělení rolí dle UserMap pokračuj na odkaz";
+                builder.AddComponents(new DiscordLinkButtonComponent(link, "Ověřit se!", false,
+                    new DiscordComponentEmoji("✅")));
             }
 
             await eventArgs.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -3,6 +3,7 @@ using DSharpPlus;
 using DSharpPlus.Entities;
 using HonzaBotner.Discord.Managers;
 using HonzaBotner.Discord.Services.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace HonzaBotner.Discord.Services.Managers
@@ -10,15 +11,23 @@ namespace HonzaBotner.Discord.Services.Managers
     public class ButtonManager : IButtonManager
     {
         private readonly ButtonOptions _buttonOptions;
+        private readonly ILogger<ButtonManager> _logger;
 
-        public ButtonManager(IOptions<ButtonOptions> buttonConfig)
+        public ButtonManager(IOptions<ButtonOptions> buttonConfig, ILogger<ButtonManager> logger)
         {
             _buttonOptions = buttonConfig.Value;
+            _logger = logger;
         }
 
         public async Task SetupVerificationButtons(DiscordMessage target)
         {
             DiscordMessage message = target;
+
+            if (_buttonOptions.VerificationId is null || _buttonOptions.StaffVerificationId is null)
+            {
+                _logger.LogWarning("'VerificationId' or 'StaffVerificationId' not set in config");
+                return;
+            }
 
             var builder = new DiscordMessageBuilder()
                 .WithContent(message.Content)

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -9,34 +9,34 @@ namespace HonzaBotner.Discord.Services.Managers
 {
     public class ButtonManager : IButtonManager
     {
-        private readonly CommonCommandOptions _config;
-        private readonly IGuildProvider _guildProvider;
+        private readonly ButtonOptions _buttonOptions;
 
-        public ButtonManager(IOptions<CommonCommandOptions> options, IGuildProvider guildProvider)
+        public ButtonManager(IOptions<ButtonOptions> buttonConfig)
         {
-            _config = options.Value;
-            _guildProvider = guildProvider;
+            _buttonOptions = buttonConfig.Value;
         }
 
-        public async Task SetupButtons()
+        public async Task SetupVerificationButtons(DiscordMessage target)
         {
-            DiscordGuild guild = await _guildProvider.GetCurrentGuildAsync();
-            DiscordChannel channel = guild.GetChannel(_config.VerificationChannelId);
-            if (channel.Type != ChannelType.Text) return;
-
-            DiscordMessage message = await channel.GetMessageAsync(_config.VerificationMessageId);
+            DiscordMessage message = target;
 
             var builder = new DiscordMessageBuilder()
                 .WithContent(message.Content)
                 .AddComponents(new DiscordComponent[]
                 {
-                    new DiscordButtonComponent(ButtonStyle.Primary, "user-verification", "Ověř se!",
+                    new DiscordButtonComponent(ButtonStyle.Primary, _buttonOptions.VerificationId, "Ověř se!",
                         false, new DiscordComponentEmoji("✅")),
-                    new DiscordButtonComponent(ButtonStyle.Secondary, "staff-verification",
+                    new DiscordButtonComponent(ButtonStyle.Secondary, _buttonOptions.StaffVerificationId,
                         "Přidat role zaměstnance", false, new DiscordComponentEmoji("👑"))
                 });
 
             await message.ModifyAsync(builder);
+        }
+
+        public async Task RemoveButtonsFromMessage(DiscordMessage target)
+        {
+            DiscordMessageBuilder builder = new DiscordMessageBuilder().WithContent(target.Content);
+            await target.ModifyAsync(builder);
         }
 
     }

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.Entities;
@@ -31,8 +30,10 @@ namespace HonzaBotner.Discord.Services.Managers
                 .WithContent(message.Content)
                 .AddComponents(new DiscordComponent[]
                 {
-                    new DiscordButtonComponent(ButtonStyle.Primary, "user-verification", "Ověř se!", false, new DiscordComponentEmoji("✅")),
-                    new DiscordButtonComponent(ButtonStyle.Secondary, "staff-verification", "Přidat role zaměstnance", false, new DiscordComponentEmoji("👑"))
+                    new DiscordButtonComponent(ButtonStyle.Primary, "user-verification", "Ověř se!",
+                        false, new DiscordComponentEmoji("✅")),
+                    new DiscordButtonComponent(ButtonStyle.Secondary, "staff-verification",
+                        "Přidat role zaměstnance", false, new DiscordComponentEmoji("👑"))
                 });
 
             await message.ModifyAsync(builder);

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -2,12 +2,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.Entities;
-using DSharpPlus.EventArgs;
 using HonzaBotner.Discord.Managers;
 using HonzaBotner.Discord.Services.Options;
 using Microsoft.Extensions.Options;
 
-namespace HonzaBotner.Discord.Services.EventHandlers
+namespace HonzaBotner.Discord.Services.Managers
 {
     public class ButtonManager : IButtonManager
     {
@@ -21,15 +20,15 @@ namespace HonzaBotner.Discord.Services.EventHandlers
 
         }
 
-        public async Task SetupButtons(GuildDownloadCompletedEventArgs eventArgs)
+        public async Task SetupButtons(IReadOnlyDictionary<ulong, DiscordGuild> guilds)
         {
-            if (eventArgs.Guilds == null) return;
+            if (guilds.Count == 0) return;
 
             DiscordGuild guild;
 
             try
             {
-                guild = eventArgs.Guilds[_dcConfig.GuildId ?? 0];
+                guild = guilds[_dcConfig.GuildId ?? 0];
             }
             catch (KeyNotFoundException)
             {
@@ -45,8 +44,8 @@ namespace HonzaBotner.Discord.Services.EventHandlers
                 .WithContent(message.Content)
                 .AddComponents(new DiscordComponent[]
                 {
-                    new DiscordButtonComponent(ButtonStyle.Success, "user-verification", "Ověř se!", false, new DiscordComponentEmoji("⚡")),
-                    new DiscordButtonComponent(ButtonStyle.Primary, "staff-verification", "Aktualizovat role zaměstnance", false, new DiscordComponentEmoji("👑"))
+                    new DiscordButtonComponent(ButtonStyle.Primary, "user-verification", "Ověř se!", false, new DiscordComponentEmoji("✅")),
+                    new DiscordButtonComponent(ButtonStyle.Secondary, "staff-verification", "Přidat role zaměstnance", false, new DiscordComponentEmoji("👑"))
                 });
 
             await message.ModifyAsync(builder);

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -11,30 +11,17 @@ namespace HonzaBotner.Discord.Services.Managers
     public class ButtonManager : IButtonManager
     {
         private readonly CommonCommandOptions _config;
-        private readonly DiscordConfig _dcConfig;
+        private readonly IGuildProvider _guildProvider;
 
-        public ButtonManager(IOptions<CommonCommandOptions> options, IOptions<DiscordConfig> config)
+        public ButtonManager(IOptions<CommonCommandOptions> options, IGuildProvider guildProvider)
         {
             _config = options.Value;
-            _dcConfig = config.Value;
-
+            _guildProvider = guildProvider;
         }
 
-        public async Task SetupButtons(IReadOnlyDictionary<ulong, DiscordGuild> guilds)
+        public async Task SetupButtons()
         {
-            if (guilds.Count == 0) return;
-
-            DiscordGuild guild;
-
-            try
-            {
-                guild = guilds[_dcConfig.GuildId ?? 0];
-            }
-            catch (KeyNotFoundException)
-            {
-                return;
-            }
-
+            DiscordGuild guild = await _guildProvider.GetCurrentGuildAsync();
             DiscordChannel channel = guild.GetChannel(_config.VerificationChannelId);
             if (channel.Type != ChannelType.Text) return;
 

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -45,8 +45,8 @@ namespace HonzaBotner.Discord.Services.EventHandlers
                 .WithContent(message.Content)
                 .AddComponents(new DiscordComponent[]
                 {
-                    new DiscordButtonComponent(ButtonStyle.Primary, "user-verification", "Ověř se!", false, new DiscordComponentEmoji("⚡")),
-                    new DiscordButtonComponent(ButtonStyle.Primary, "staff-verification", "Získat role zaměstnance", false, new DiscordComponentEmoji("👑"))
+                    new DiscordButtonComponent(ButtonStyle.Success, "user-verification", "Ověř se!", false, new DiscordComponentEmoji("⚡")),
+                    new DiscordButtonComponent(ButtonStyle.Primary, "staff-verification", "Aktualizovat role zaměstnance", false, new DiscordComponentEmoji("👑"))
                 });
 
             await message.ModifyAsync(builder);

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using HonzaBotner.Discord.Managers;
+using HonzaBotner.Discord.Services.Options;
+using Microsoft.Extensions.Options;
+
+namespace HonzaBotner.Discord.Services.EventHandlers
+{
+    public class ButtonManager : IButtonManager
+    {
+        private readonly CommonCommandOptions _config;
+        private readonly DiscordConfig _dcConfig;
+
+        public ButtonManager(IOptions<CommonCommandOptions> options, IOptions<DiscordConfig> config)
+        {
+            _config = options.Value;
+            _dcConfig = config.Value;
+
+        }
+
+        public async Task SetupButtons(GuildDownloadCompletedEventArgs eventArgs)
+        {
+            if (eventArgs.Guilds == null) return;
+
+            DiscordGuild guild;
+
+            try
+            {
+                guild = eventArgs.Guilds[_dcConfig.GuildId ?? 0];
+            }
+            catch (KeyNotFoundException)
+            {
+                return;
+            }
+
+            DiscordChannel channel = guild.GetChannel(_config.VerificationChannelId);
+            if (channel.Type != ChannelType.Text) return;
+
+            DiscordMessage message = await channel.GetMessageAsync(_config.VerificationMessageId);
+
+            var builder = new DiscordMessageBuilder()
+                .WithContent(message.Content)
+                .AddComponents(new DiscordComponent[]
+                {
+                    new DiscordButtonComponent(ButtonStyle.Primary, "user-verification", "Ověř se!", false, new DiscordComponentEmoji("⚡")),
+                    new DiscordButtonComponent(ButtonStyle.Primary, "staff-verification", "Získat role zaměstnance", false, new DiscordComponentEmoji("👑"))
+                });
+
+            await message.ModifyAsync(builder);
+        }
+
+    }
+}

--- a/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ButtonManager.cs
@@ -19,10 +19,8 @@ namespace HonzaBotner.Discord.Services.Managers
             _logger = logger;
         }
 
-        public async Task SetupVerificationButtons(DiscordMessage target)
+        public async Task SetupVerificationButtons(DiscordMessage message)
         {
-            DiscordMessage message = target;
-
             if (_buttonOptions.VerificationId is null || _buttonOptions.StaffVerificationId is null)
             {
                 _logger.LogWarning("'VerificationId' or 'StaffVerificationId' not set in config");
@@ -31,13 +29,22 @@ namespace HonzaBotner.Discord.Services.Managers
 
             var builder = new DiscordMessageBuilder()
                 .WithContent(message.Content)
-                .AddComponents(new DiscordComponent[]
-                {
-                    new DiscordButtonComponent(ButtonStyle.Primary, _buttonOptions.VerificationId, "Ověř se!",
-                        false, new DiscordComponentEmoji("✅")),
-                    new DiscordButtonComponent(ButtonStyle.Secondary, _buttonOptions.StaffVerificationId,
-                        "Přidat role zaměstnance", false, new DiscordComponentEmoji("👑"))
-                });
+                .AddComponents(
+                    new DiscordButtonComponent(
+                        ButtonStyle.Primary,
+                        _buttonOptions.VerificationId,
+                        "Ověř se",
+                        false,
+                        new DiscordComponentEmoji("✅")
+                    ),
+                    new DiscordButtonComponent(
+                        ButtonStyle.Secondary,
+                        _buttonOptions.StaffVerificationId,
+                        "Přidat role zaměstnance",
+                        false,
+                        new DiscordComponentEmoji("👑")
+                    )
+                );
 
             await message.ModifyAsync(builder);
         }
@@ -47,6 +54,5 @@ namespace HonzaBotner.Discord.Services.Managers
             DiscordMessageBuilder builder = new DiscordMessageBuilder().WithContent(target.Content);
             await target.ModifyAsync(builder);
         }
-
     }
 }

--- a/src/HonzaBotner.Discord.Services/Options/ButtonOptions.cs
+++ b/src/HonzaBotner.Discord.Services/Options/ButtonOptions.cs
@@ -4,8 +4,8 @@ namespace HonzaBotner.Discord.Services.Options
     {
         public static string ConfigName => "ButtonOptions";
 
-        public string VerificationId { get; set; } = "verification-user";
-        public string StaffVerificationId { get; set; } = "verification-staff";
-        public string StaffRemoveRoleId { get; set; } = "verification-remove-staff";
+        public string? VerificationId { get; set; }
+        public string? StaffVerificationId { get; set; }
+        public string? StaffRemoveRoleId { get; set; }
     }
 }

--- a/src/HonzaBotner.Discord.Services/Options/ButtonOptions.cs
+++ b/src/HonzaBotner.Discord.Services/Options/ButtonOptions.cs
@@ -1,0 +1,11 @@
+namespace HonzaBotner.Discord.Services.Options
+{
+    public class ButtonOptions
+    {
+        public static string ConfigName => "ButtonOptions";
+
+        public string VerificationId { get; set; } = "verification-user";
+        public string StaffVerificationId { get; set; } = "verification-staff";
+        public string StaffRemoveRoleId { get; set; } = "verification-remove-staff";
+    }
+}

--- a/src/HonzaBotner.Discord.Services/Options/CommonCommandOptions.cs
+++ b/src/HonzaBotner.Discord.Services/Options/CommonCommandOptions.cs
@@ -13,8 +13,6 @@
 
         public ulong VerificationMessageId { get; set; }
         public ulong VerificationChannelId { get; set; }
-        public string VerificationEmojiName { get; set; } = "";
-        public string StaffVerificationEmojiName { get; set; } = "";
 
         public ulong GentlemenChannelId { get; set; }
         public string GentlemenFilePath { get; set; } = "";

--- a/src/HonzaBotner.Discord.Services/Options/CommonCommandOptions.cs
+++ b/src/HonzaBotner.Discord.Services/Options/CommonCommandOptions.cs
@@ -11,9 +11,6 @@
         public ulong BotRoleId { get; set; }
         public string? HugEmoteName { get; set; }
 
-        public ulong VerificationMessageId { get; set; }
-        public ulong VerificationChannelId { get; set; }
-
         public ulong GentlemenChannelId { get; set; }
         public string GentlemenFilePath { get; set; } = "";
 

--- a/src/HonzaBotner.Discord.Services/ServiceCollectionExtensions.cs
+++ b/src/HonzaBotner.Discord.Services/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ namespace HonzaBotner.Discord.Services
             services.Configure<PinOptions>(configuration.GetSection(PinOptions.ConfigName));
             services.Configure<InfoOptions>(configuration.GetSection(InfoOptions.ConfigName));
             services.Configure<ReminderOptions>(configuration.GetSection(ReminderOptions.ConfigName));
+            services.Configure<ButtonOptions>(configuration.GetSection(ButtonOptions.ConfigName));
 
             return services;
         }

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -18,19 +18,17 @@ namespace HonzaBotner.Discord
         private readonly EventHandler.EventHandler _eventHandler;
         private readonly CommandConfigurator _configurator;
         private readonly IVoiceManager _voiceManager;
-        private readonly IButtonManager _buttonManager;
 
         private DiscordClient Client => _discordWrapper.Client;
         private CommandsNextExtension Commands => _discordWrapper.Commands;
 
         public DiscordBot(DiscordWrapper discordWrapper, EventHandler.EventHandler eventHandler,
-            CommandConfigurator configurator, IVoiceManager voiceManager, IButtonManager buttonManager)
+            CommandConfigurator configurator, IVoiceManager voiceManager)
         {
             _discordWrapper = discordWrapper;
             _eventHandler = eventHandler;
             _configurator = configurator;
             _voiceManager = voiceManager;
-            _buttonManager = buttonManager;
         }
 
         public async Task Run(CancellationToken cancellationToken)
@@ -75,7 +73,6 @@ namespace HonzaBotner.Discord
 
             // Run managers' init processes.
             await _voiceManager.DeleteAllUnusedVoiceChannelsAsync();
-            await _buttonManager.SetupButtons();
         }
 
         private Task Client_ClientError(DiscordClient sender, ClientErrorEventArgs e)

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -75,7 +75,7 @@ namespace HonzaBotner.Discord
 
             // Run managers' init processes.
             await _voiceManager.DeleteAllUnusedVoiceChannelsAsync();
-            await _buttonManager.SetupButtons(e);
+            await _buttonManager.SetupButtons(e.Guilds);
         }
 
         private Task Client_ClientError(DiscordClient sender, ClientErrorEventArgs e)

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -75,7 +75,7 @@ namespace HonzaBotner.Discord
 
             // Run managers' init processes.
             await _voiceManager.DeleteAllUnusedVoiceChannelsAsync();
-            await _buttonManager.SetupButtons(e.Guilds);
+            await _buttonManager.SetupButtons();
         }
 
         private Task Client_ClientError(DiscordClient sender, ClientErrorEventArgs e)

--- a/src/HonzaBotner.Discord/Managers/IButtonManager.cs
+++ b/src/HonzaBotner.Discord/Managers/IButtonManager.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using DSharpPlus.EventArgs;
+
+namespace HonzaBotner.Discord.Managers
+{
+    public interface IButtonManager
+    {
+        Task SetupButtons(GuildDownloadCompletedEventArgs args);
+    }
+}

--- a/src/HonzaBotner.Discord/Managers/IButtonManager.cs
+++ b/src/HonzaBotner.Discord/Managers/IButtonManager.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
 
 namespace HonzaBotner.Discord.Managers
 {
@@ -7,6 +8,14 @@ namespace HonzaBotner.Discord.Managers
         /// <summary>
         /// Sets up default buttons on verification messages
         /// </summary>
-        Task SetupButtons();
+        /// <param name="target">Target message where the buttons will be added</param>
+        Task SetupVerificationButtons(DiscordMessage target);
+
+        /// <summary>
+        /// Removes all button interactions from provided message
+        /// </summary>
+        /// <param name="target">Target message</param>
+        /// <returns></returns>
+        Task RemoveButtonsFromMessage(DiscordMessage target);
     }
 }

--- a/src/HonzaBotner.Discord/Managers/IButtonManager.cs
+++ b/src/HonzaBotner.Discord/Managers/IButtonManager.cs
@@ -9,7 +9,6 @@ namespace HonzaBotner.Discord.Managers
         /// <summary>
         /// Sets up default buttons on verification messages
         /// </summary>
-        /// <param name="guilds">Dictionary of GuildID and DiscordGuild the bot is connected to</param>
-        Task SetupButtons(IReadOnlyDictionary<ulong, DiscordGuild> guilds);
+        Task SetupButtons();
     }
 }

--- a/src/HonzaBotner.Discord/Managers/IButtonManager.cs
+++ b/src/HonzaBotner.Discord/Managers/IButtonManager.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using DSharpPlus.Entities;
 
 namespace HonzaBotner.Discord.Managers
 {

--- a/src/HonzaBotner.Discord/Managers/IButtonManager.cs
+++ b/src/HonzaBotner.Discord/Managers/IButtonManager.cs
@@ -1,10 +1,15 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using DSharpPlus.EventArgs;
+using DSharpPlus.Entities;
 
 namespace HonzaBotner.Discord.Managers
 {
     public interface IButtonManager
     {
-        Task SetupButtons(GuildDownloadCompletedEventArgs args);
+        /// <summary>
+        /// Sets up default buttons on verification messages
+        /// </summary>
+        /// <param name="guilds">Dictionary of GuildID and DiscordGuild the bot is connected to</param>
+        Task SetupButtons(IReadOnlyDictionary<ulong, DiscordGuild> guilds);
     }
 }

--- a/src/HonzaBotner/Properties/launchSettings.json
+++ b/src/HonzaBotner/Properties/launchSettings.json
@@ -12,14 +12,14 @@
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "HonzaBotner": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },

--- a/src/HonzaBotner/Startup.cs
+++ b/src/HonzaBotner/Startup.cs
@@ -88,6 +88,7 @@ namespace HonzaBotner
                 // Managers
                 .AddTransient<IVoiceManager, VoiceManager>()
                 .AddTransient<IReminderManager, ReminderManager>()
+                .AddTransient<IButtonManager, ButtonManager>()
 
                 // Jobs
                 .AddScoped<TriggerRemindersJobProvider>()

--- a/src/HonzaBotner/appsettings.BotDev.json
+++ b/src/HonzaBotner/appsettings.BotDev.json
@@ -13,7 +13,7 @@
         ]
     },
     "CVUT": {
-        "AppBaseUrl": "http://fit-cvut-discord-test.herokuapp.com"
+        "AppBaseUrl": "https://fit-cvut-discord-test.herokuapp.com"
     },
     "CommonCommandOptions": {
         "ModRoleId": 811385023705645086,
@@ -23,8 +23,6 @@
         "HugEmoteName": "",
         "VerificationMessageId": 811282731195432991,
         "VerificationChannelId": 811282707215679569,
-        "VerificationEmojiName": "⚡",
-        "StaffVerificationEmojiName": "👑",
         "GentlemenChannelId": 0,
         "GentlemenFilePath": "Static/gentleman.gif",
         "HornyJailRoleId": 0,

--- a/src/HonzaBotner/appsettings.BotDev.json
+++ b/src/HonzaBotner/appsettings.BotDev.json
@@ -21,8 +21,6 @@
         "AuthenticatedRoleId": 809436691470614539,
         "MuteRoleId": 0,
         "HugEmoteName": "",
-        "VerificationMessageId": 811282731195432991,
-        "VerificationChannelId": 811282707215679569,
         "GentlemenChannelId": 0,
         "GentlemenFilePath": "Static/gentleman.gif",
         "HornyJailRoleId": 0,
@@ -50,5 +48,10 @@
         "HostRoleIds": [
             887764801659478026
         ]
+    },
+    "ButtonOptions": {
+        "VerificationId": "verification-user",
+        "StaffVerificationId": "verification-staff",
+        "StaffRemoveRoleId": "verification-remove-staff"
     }
 }

--- a/src/HonzaBotner/appsettings.BotDev.json
+++ b/src/HonzaBotner/appsettings.BotDev.json
@@ -13,7 +13,7 @@
         ]
     },
     "CVUT": {
-        "AppBaseUrl": "https://fit-cvut-discord-test.herokuapp.com"
+        "AppBaseUrl": "http://fit-cvut-discord-test.herokuapp.com"
     },
     "CommonCommandOptions": {
         "ModRoleId": 811385023705645086,

--- a/src/HonzaBotner/appsettings.CvutFit.json
+++ b/src/HonzaBotner/appsettings.CvutFit.json
@@ -7,7 +7,7 @@
         }
     },
     "CVUT": {
-        "AppBaseUrl": "http://fit-cvut-discord-test.herokuapp.com"
+        "AppBaseUrl": "https://fit-cvut-discord-test.herokuapp.com"
     },
     "Discord": {
         "GuildId": 366970031445377024,
@@ -23,8 +23,6 @@
         "HugEmoteName": "peepoHugger",
         "VerificationMessageId": 686745124885364770,
         "VerificationChannelId": 507515506073403402,
-        "VerificationEmojiName": "✅",
-        "StaffVerificationEmojiName": "👑",
         "GentlemenChannelId": 756616473283133551,
         "GentlemenFilePath": "Static/gentleman.gif",
         "HornyJailRoleId": 768941177872318484,

--- a/src/HonzaBotner/appsettings.CvutFit.json
+++ b/src/HonzaBotner/appsettings.CvutFit.json
@@ -21,8 +21,6 @@
         "AuthenticatedRoleId": 681559148546359432,
         "MuteRoleId": 750276752663904306,
         "HugEmoteName": "peepoHugger",
-        "VerificationMessageId": 686745124885364770,
-        "VerificationChannelId": 507515506073403402,
         "GentlemenChannelId": 756616473283133551,
         "GentlemenFilePath": "Static/gentleman.gif",
         "HornyJailRoleId": 768941177872318484,
@@ -92,5 +90,10 @@
             714950745635422271,
             691907282019155989
         ]
+    },
+    "ButtonOptions": {
+        "VerificationId": "verification-user",
+        "StaffVerificationId": "verification-staff",
+        "StaffRemoveRoleId": "verification-remove-staff"
     }
 }

--- a/src/HonzaBotner/appsettings.CvutFit.json
+++ b/src/HonzaBotner/appsettings.CvutFit.json
@@ -7,7 +7,7 @@
         }
     },
     "CVUT": {
-        "AppBaseUrl": "https://fit-cvut-discord-test.herokuapp.com"
+        "AppBaseUrl": "http://fit-cvut-discord-test.herokuapp.com"
     },
     "Discord": {
         "GuildId": 366970031445377024,

--- a/src/HonzaBotner/appsettings.Development.json
+++ b/src/HonzaBotner/appsettings.Development.json
@@ -21,8 +21,6 @@
         "AuthenticatedRoleId": 809436691470614539,
         "MuteRoleId": 0,
         "HugEmoteName": "",
-        "VerificationMessageId": 811282731195432991,
-        "VerificationChannelId": 811282707215679569,
         "GentlemenChannelId": 820299208120336415,
         "GentlemenFilePath": "Static/gentleman.gif",
         "HornyJailRoleId": 760050336366329856,
@@ -64,5 +62,10 @@
         "HostRoleIds": [
             887764801659478026
         ]
+    },
+    "ButtonOptions": {
+        "VerificationId": "verification-user",
+        "StaffVerificationId": "verification-staff",
+        "StaffRemoveRoleId": "verification-remove-staff"
     }
 }

--- a/src/HonzaBotner/appsettings.Development.json
+++ b/src/HonzaBotner/appsettings.Development.json
@@ -23,8 +23,6 @@
         "HugEmoteName": "",
         "VerificationMessageId": 811282731195432991,
         "VerificationChannelId": 811282707215679569,
-        "VerificationEmojiName": "⚡",
-        "StaffVerificationEmojiName": "👑",
         "GentlemenChannelId": 820299208120336415,
         "GentlemenFilePath": "Static/gentleman.gif",
         "HornyJailRoleId": 760050336366329856,


### PR DESCRIPTION
This PR implemets basic functionality of discord [Buttons](https://discord.com/developers/docs/interactions/message-components#buttons) and provides space for future button's implementations.
Right now, buttons are used only to verify members on severs. It listents to specific button's press and reacts.
Discord makes it possible to display 4 different [colors](https://dsharpplus.github.io/api/DSharpPlus.ButtonStyle.html) on buttons (Blurple, Grey, Green, and Red) as well as display different emojis.

-------------------
## Current changelog:
- Add 2 new commands

1. `message buttons setup %url%` will add verification buttons to that message - needs to be sent by bot!
2. `message buttons remove %url%` removes **all** buttons from the message - needs to be sent by bot!

- Map verification event handlers on InteractionCreateEvent instead of ReactionEvent
- Responses now go directly into the channel instead of DM - thay are invisible to other users
- Made Staff verification more personalized.
  - Not authenticated -> "You need to authenticate first" + auth button
  - Authenticated, no staff roles ->"Click to add staff roles" + staff button
  - Authenticated, with staff roles -> "Click to update/remove staff roles" + staff button AND remove roles button
  - Remove roles updates message to confirm roles removed
  - Everything is invisible to others
- Created IButtonManager with functions to setup verification buttons on a message and delete all buttons on a message
- Removed VerificationChannel and MessageIDs from config, removed reaction emojis from config
- Added config fields for internal button IDs - please **don't edit this**, especially after seting up verification buttons