### PR TITLE
Fix db row growing

### DIFF
--- a/src/HonzaBotner/Startup.cs
+++ b/src/HonzaBotner/Startup.cs
@@ -1,6 +1,5 @@
 using System;
 using Hangfire;
-using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using HangfireBasicAuthenticationFilter;
 using HonzaBotner.Discord.Services.Commands;

--- a/src/HonzaBotner/Startup.cs
+++ b/src/HonzaBotner/Startup.cs
@@ -1,4 +1,6 @@
+using System;
 using Hangfire;
+using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using HangfireBasicAuthenticationFilter;
 using HonzaBotner.Discord.Services.Commands;
@@ -96,7 +98,11 @@ namespace HonzaBotner
                 .AddScoped<TriggerRemindersJobProvider>()
                 ;
 
-            services.AddHangfire(config => { config.UsePostgreSqlStorage(connectionString); });
+            services.AddHangfire(config =>
+            {
+                config.UsePostgreSqlStorage(connectionString,
+                    new PostgreSqlStorageOptions { JobExpirationCheckInterval = TimeSpan.FromMinutes(15) });
+            });
             services.AddHangfireServer(serverOptions => { serverOptions.WorkerCount = 3; });
         }
 


### PR DESCRIPTION
Hangfire adds logs very fast.
It should to my understanding check and delete every hour every expired job log,
but that is not sufficient to our limitations of the Heroku Postgresql DB.
This PR reduces the check from 60 to 15 minutes.

![image](https://user-images.githubusercontent.com/5287596/135178538-5ea8b020-90ac-40aa-a2c3-40698eb0ddbc.png)

and few minutes later:
![image](https://user-images.githubusercontent.com/5287596/135178545-fe7282b3-5578-4d21-bb1a-a4274ab71168.png)
