### PR TITLE
👷 Specify platform in release build

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,14 +19,12 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      working-directory: ./src/HonzaBotner
-      run: dotnet publish --configuration Release --no-restore -o botner-build
+      run: dotnet publish src/HonzaBotner/HonzaBotner.csproj -o botner-linux-musl-x64 -c Release -r linux-musl-x64 --no-self-contained -p:PublishSingleFile=true
     - name: Pack the build to tar
-      working-directory: ./src/HonzaBotner
-      run: tar -czvf botner-build.tar.gz botner-build
+      run: tar -czvf botner-linux-musl-x64.tar.gz botner-linux-musl-x64
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: src/HonzaBotner/botner-build.tar.gz
+        files: botner-linux-musl-x64.tar.gz
         generate_release_notes: true


### PR DESCRIPTION
Specifies `linux-musl-x64` target for `dotnet publish`