### PR TITLE
Improve reminders

### DIFF
--- a/src/HonzaBotner.Discord.Services/Commands/ReminderCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/ReminderCommands.cs
@@ -16,9 +16,8 @@ namespace HonzaBotner.Discord.Services.Commands
 {
     [Group("reminder")]
     [Aliases("remind")]
-    [Description("Commands to manager reminders.")]
+    [Description("Create a new reminder using formats like: `18.08.2018 07:22:16`, `07:22:16`, `in 2 hours`, ...")]
     [ModuleLifespan(ModuleLifespan.Transient)]
-    [Cooldown(2, 60 * 60, CooldownBucketType.User)]
     [RequireGuild]
     public class ReminderCommands : BaseCommandModule
     {
@@ -39,10 +38,10 @@ namespace HonzaBotner.Discord.Services.Commands
             _reminderManager = reminderManager;
         }
 
-        [GroupCommand]
         [Command("create")]
         [Aliases("me")] // Allows a more "fluent" usage ::remind me <>
-        [Description("Create a new reminder.")]
+        [Description("Create a new reminder using formats like: `18.08.2018 07:22:16`, `07:22:16`, `in 2 hours`, ...")]
+        [Cooldown(2, 60 * 60, CooldownBucketType.User)]
         public async Task Create(
             CommandContext context,
             [Description("Date or time of the reminder")]
@@ -68,7 +67,8 @@ namespace HonzaBotner.Discord.Services.Commands
             {
                 await context.RespondErrorAsync(
                     $"Cannot parse datetime string `{rawDatetime}`",
-                    "Try using an explicit datetime or expressions like `in 30 minutes`, `tomorrow at 8:00`, ..."
+                    "Try using an explicit datetime or expressions like:" +
+                    "`in 30 minutes`, `tomorrow at 8:00`, `18.08.2021 07:22:16`, ..."
                 );
                 return;
             }

--- a/src/HonzaBotner.Discord.Services/EventHandlers/ReminderReactionsHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/ReminderReactionsHandler.cs
@@ -56,7 +56,6 @@ namespace HonzaBotner.Discord.Services.EventHandlers
                 await _service.DeleteReminderAsync(reminder.Id);
                 await arguments.Message.ModifyAsync("",
                     await _reminderManager.CreateCanceledReminderEmbedAsync(reminder));
-                await arguments.Message.DeleteAllReactionsAsync("Reminder canceled");
 
                 return EventHandlerResult.Stop;
             }
@@ -71,7 +70,7 @@ namespace HonzaBotner.Discord.Services.EventHandlers
 
             // Otherwise just remove the emoji...
             await arguments.Message.DeleteReactionAsync(arguments.Emoji, arguments.User, "It is not a valid reaction.");
-            return EventHandlerResult.Continue;
+            return EventHandlerResult.Stop;
         }
     }
 }

--- a/src/HonzaBotner.Discord.Services/Jobs/TriggerRemindersJobProvider.cs
+++ b/src/HonzaBotner.Discord.Services/Jobs/TriggerRemindersJobProvider.cs
@@ -75,18 +75,21 @@ namespace HonzaBotner.Discord.Services.Jobs
                 // DM all users.
                 foreach (ulong user in receivers)
                 {
-                    DiscordMember? member = await message.Channel.Guild.GetMemberAsync(user);
-                    if (member is null) continue;
-
                     try
                     {
+                        DiscordMember? member = await message.Channel.Guild.GetMemberAsync(user);
+                        if (member is null) continue;
                         DiscordDmChannel dmChannel = await member.CreateDmChannelAsync();
                         await dmChannel.SendMessageAsync(embed: embed);
                     }
                     catch (Exception e)
                     {
-                        if (e is NotFoundException) continue;
-                        if (e is not UnauthorizedException) throw;
+                        if (e is NotFoundException) continue; // User not found, skip him
+                        if (e is not UnauthorizedException) // Anything else apart from user refusing direct messages
+                        {
+                            _logger.LogError(e, "Exception when sending reminder direct message: {Message}",
+                                e.Message);
+                        }
                     }
 
                     remindedUsers.Append("<@" + user + ">, ");

--- a/src/HonzaBotner.Discord.Services/Jobs/TriggerRemindersJobProvider.cs
+++ b/src/HonzaBotner.Discord.Services/Jobs/TriggerRemindersJobProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
@@ -69,7 +70,7 @@ namespace HonzaBotner.Discord.Services.Jobs
                 receivers.Add(reminder.OwnerId);
 
                 DiscordEmbed embed = await _reminderManager.CreateDmReminderEmbedAsync(reminder);
-                string remindedUsers = "Ahoj ";
+                var remindedUsers = new StringBuilder("Ahoj ");
 
                 // DM all users.
                 foreach (ulong user in receivers)
@@ -88,12 +89,12 @@ namespace HonzaBotner.Discord.Services.Jobs
                         if (e is not UnauthorizedException) throw;
                     }
 
-                    remindedUsers += ("<@" + user + ">, ");
+                    remindedUsers.Append("<@" + user + ">, ");
 
                 }
 
-                remindedUsers = remindedUsers.Remove(remindedUsers.LastIndexOf(",", StringComparison.Ordinal));
-                remindedUsers += " - nezapomeňte na `" + reminder.Content + "`";
+                remindedUsers = remindedUsers.Remove(remindedUsers.Length - 2, 2);
+                remindedUsers.Append(" - nezapomeň" + (receivers.Count > 1 ? "te" : "") + " na `" + reminder.Content + "`");
 
                 DiscordEmbed expiredEmbed = await _reminderManager.CreateExpiredReminderEmbedAsync(reminder);
 
@@ -101,7 +102,7 @@ namespace HonzaBotner.Discord.Services.Jobs
                 await message.ModifyAsync("", expiredEmbed);
                 await new DiscordMessageBuilder()
                     .WithReply(message.Id)
-                    .WithContent(remindedUsers)
+                    .WithContent(remindedUsers.ToString())
                     .SendAsync(message.Channel.Guild.GetChannel(message.ChannelId));
 
             }

--- a/src/HonzaBotner.Discord.Services/Managers/ReminderManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ReminderManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using HonzaBotner.Discord.Services.Extensions;
 using HonzaBotner.Discord.Managers;
@@ -69,18 +70,15 @@ namespace HonzaBotner.Discord.Services.Managers
 
             DiscordMember? author = await guild.GetMemberAsync(reminder.OwnerId);
 
+            string datetime = useDateTime ? "\n\n<t:" + Math.Floor(reminder.DateTime.Subtract(new DateTime(1970, 1, 1)).TotalSeconds) + ":f>" : "";
+
             var embedBuilder = new DiscordEmbedBuilder()
                 .WithTitle(title)
                 .WithAuthor(
                     author?.DisplayName ?? "Unknown user",
                     iconUrl: author?.AvatarUrl)
-                .WithDescription(reminder.Content.RemoveDiscordMentions(guild, _logger))
+                .WithDescription(reminder.Content.RemoveDiscordMentions(guild, _logger) + datetime)
                 .WithColor(color);
-
-            if (useDateTime)
-            {
-                embedBuilder.WithTimestamp(reminder.DateTime);
-            }
 
             return embedBuilder.Build();
         }

--- a/src/HonzaBotner.Discord.Services/Managers/ReminderManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ReminderManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using HonzaBotner.Discord.Services.Extensions;
 using HonzaBotner.Discord.Managers;
@@ -67,16 +66,8 @@ namespace HonzaBotner.Discord.Services.Managers
         )
         {
             var guild = await _guildProvider.GetCurrentGuildAsync();
-            DiscordMember? author;
 
-            try
-            {
-                author = await guild.GetMemberAsync(reminder.OwnerId);
-            }
-            catch (Exception)
-            {
-                author = null;
-            }
+            DiscordMember? author = await guild.GetMemberAsync(reminder.OwnerId);
 
             var embedBuilder = new DiscordEmbedBuilder()
                 .WithTitle(title)

--- a/src/HonzaBotner.Discord/DiscordBot.cs
+++ b/src/HonzaBotner.Discord/DiscordBot.cs
@@ -135,6 +135,16 @@ namespace HonzaBotner.Discord
                             DiscordEmoji permissionEmoji = DiscordEmoji.FromName(e.Context.Client, ":no_entry:");
                             DiscordEmoji timerEmoji = DiscordEmoji.FromName(e.Context.Client, ":alarm_clock:");
 
+                            if (failedCheck is CooldownAttribute)
+                            {
+                                if (exception.Context.Guild is not null &&
+                                    (exception.Context.Member.Permissions & Permissions.ManageMessages) != 0)
+                                {
+                                    await exception.Command.ExecuteAsync(exception.Context);
+                                    return;
+                                }
+                            }
+
                             DiscordEmbed embed = failedCheck switch
                             {
                                 RequireGuildAttribute => new DiscordEmbedBuilder()


### PR DESCRIPTION
On reminder cancellation or expiration, bot doesn't remove reactions (requested in #221 )

Once completed, bot messages given channel and pings people (requested in #221 ) - still has space for improvement, design is a bit plain

Admins are no longer subjected to cooldowns - dirty coding. It is not checking for Admin role since it's in different level of abstraction than configs and it would be messy to bring them there. Checking for ManageMessages permission instead. ( reported in #227 )

User gets more detailed help about date-time format - on error, help command, or default reminder command. Included some examples from C# docs. (requested in #221 )

Created embed with time contains exact date and time of reminder - requested in #221 

New reminder is no longer group command, instead help command is default. - Made it confusing when people were just trying to learn how to use them and it immediately counted towards cooldown, so sometimes they even didn't manage to create one. QoL

Cleaned up code a bit  - Getting invalid Member by ID doesn't throw error but returns null. Also, no reason to have failed reminder as Critical, especially when listening to everything, even some common errors; in listener for reaction, once we remove reaction in the last block, no need for checks to continue, reaction doesn't exist anymore.

Fixed bug which shut down whole direct message sending loop when one error occured (reported in #221 ) - try catch was set up with catching outside loop - escaping it on each error. moved try catch inside.