### PR TITLE
CodeQL: Temp fix dotnet 6.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "6.0",
-    "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "version": "6.0.100",
+    "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
CodeQL is failing every run since the developers haven't managed to keep up to date with dotnet version. Stating exact version in global.json is a workaround to force CodeQL to download that specified version.
rollForward will ensure that the rest of us are staying up to date - picking always latest installed version for compilation.