### PR TITLE
Decrease frequency of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,3 @@ updates:
     commit-message:
       prefix: "⬆️"
     target-branch: "develop"
-    labels:
-      - "release: dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,9 @@ updates:
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "⬆️"
     target-branch: "develop"
+    labels:
+      - "release: dependencies"


### PR DESCRIPTION
As we switched to nightly on DSharpPlus, the PRs are going to be spammed now with updates for this package. Decrease frequency of this checking from daily to weekly (defaults to Monday). This doesn't include security updates and forced checks, which will happen immediately. Also change labels and commit message to align more with how we manually label commits ourselves.