### PR TITLE
Improvements in the Sha256HashService

### DIFF
--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -9,7 +9,7 @@ public class Sha256HashService : IHashService
 {
     private const int HashBytesSize = 256 / 8;
     
-    private static ReadOnlySpan<byte> HexAlphabetSpan => new[]
+    private static ReadOnlySpan<byte> HexAlphabet => new[]
     {
         (byte)'0',
         (byte)'1',

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -8,16 +8,43 @@ namespace HonzaBotner.Services;
 public class Sha256HashService : IHashService
 {
     private const int HashBytesSize = 256 / 8;
+    
+    private static ReadOnlySpan<byte> HexAlphabetSpan => new[]
+    {
+        (byte)'0',
+        (byte)'1',
+        (byte)'2',
+        (byte)'3',
+        (byte)'4',
+        (byte)'5',
+        (byte)'6',
+        (byte)'7',
+        (byte)'8',
+        (byte)'9',
+        (byte)'a',
+        (byte)'b',
+        (byte)'c',
+        (byte)'d',
+        (byte)'e',
+        (byte)'f',
+    };
 
     public string Hash(string input)
     {
-        var encLen = Encoding.UTF8.GetMaxByteCount(input.Length);
+        var encLen = (input.Length + 1) * 3;
         var enc = encLen <= 1024 ? stackalloc byte[encLen] : new byte[encLen];
         Span<byte> bytes = stackalloc byte[HashBytesSize];
+        Span<char> res = stackalloc char[HashBytesSize * 2];
 
         var len = Encoding.UTF8.GetBytes(input, enc);
         SHA256.HashData(enc[..len], bytes);
 
-        return Convert.ToHexString(bytes);
+        for (int i = 0, j = 0; i < HashBytesSize; ++i, ++j)
+        {
+            res[j] = (char)HexAlphabet[bytes[i] >> 4];
+            res[++j] = (char)HexAlphabet[bytes[i] & 0xF];
+        }
+
+        return new string(res);
     }
 }

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -6,17 +6,20 @@ namespace HonzaBotner.Services;
 
 public class Sha256HashService : IHashService
 {
+    private static readonly char[] HexAlphabet = new char[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
     public string Hash(string input)
     {
         byte[] toBeHashed = Encoding.UTF8.GetBytes(input);
         byte[] bytes = SHA256.HashData(toBeHashed);
 
-        StringBuilder strB = new(64);
-        foreach (byte b in bytes)
+        var c = new char[bytes.Length * 2];
+        for (int i = 0, j = 0; i < bytes.Length; ++i)
         {
-            strB.Append(b.ToString("x2"));
+            c[j] = HexAlphabet[bytes[i] >> 4];
+            c[++j] = HexAlphabet[bytes[i] & 0xF];
         }
 
-        return strB.ToString();
+        return new string(c);
     }
 }

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -14,7 +14,7 @@ public class Sha256HashService : IHashService
         byte[] bytes = SHA256.HashData(toBeHashed);
 
         var c = new char[bytes.Length * 2];
-        for (int i = 0, j = 0; i < bytes.Length; ++i)
+        for (int i = 0, j = 0; i < bytes.Length; ++i, ++j)
         {
             c[j] = HexAlphabet[bytes[i] >> 4];
             c[++j] = HexAlphabet[bytes[i] & 0xF];

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using System.Text;
 using HonzaBotner.Services.Contract;
@@ -6,20 +7,44 @@ namespace HonzaBotner.Services;
 
 public class Sha256HashService : IHashService
 {
-    private static readonly char[] HexAlphabet = new char[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    private static ReadOnlySpan<byte> HexAlphabet => new []
+    {
+        (byte) '0',
+        (byte) '1',
+        (byte) '2',
+        (byte) '3',
+        (byte) '4',
+        (byte) '5',
+        (byte) '6',
+        (byte) '7',
+        (byte) '8',
+        (byte) '9',
+        (byte) 'a',
+        (byte) 'b',
+        (byte) 'c',
+        (byte) 'd',
+        (byte) 'e',
+        (byte) 'f',
+    };
+
+    private const int HashBytesSize = 256 / 8;
 
     public string Hash(string input)
     {
-        var toBeHashed = Encoding.UTF8.GetBytes(input);
-        var bytes = SHA256.HashData(toBeHashed);
+        var encLen = Encoding.UTF8.GetMaxByteCount(input.Length);
+        var enc = encLen <= 1024 ? stackalloc byte[encLen] : new byte[encLen];
+        Span<byte> bytes = stackalloc byte[HashBytesSize];
+        Span<char> res = stackalloc char[HashBytesSize * 2];
 
-        var c = new char[bytes.Length * 2];
-        for (int i = 0, j = 0; i < bytes.Length; ++i, ++j)
+        var len = Encoding.UTF8.GetBytes(input, enc);
+        SHA256.HashData(enc[..len], bytes);
+
+        for (int i = 0, j = 0; i < HashBytesSize; ++i, ++j)
         {
-            c[j] = HexAlphabet[bytes[i] >> 4];
-            c[++j] = HexAlphabet[bytes[i] & 0xF];
+            res[j] = (char) HexAlphabet[bytes[i] >> 4];
+            res[++j] = (char) HexAlphabet[bytes[i] & 0xF];
         }
 
-        return new string(c);
+        return new string(res);
     }
 }

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -7,44 +7,16 @@ namespace HonzaBotner.Services;
 
 public class Sha256HashService : IHashService
 {
-    private const int HashBytesSize = 256 / 8;
-    
-    private static ReadOnlySpan<byte> HexAlphabet => new[]
-    {
-        (byte)'0',
-        (byte)'1',
-        (byte)'2',
-        (byte)'3',
-        (byte)'4',
-        (byte)'5',
-        (byte)'6',
-        (byte)'7',
-        (byte)'8',
-        (byte)'9',
-        (byte)'a',
-        (byte)'b',
-        (byte)'c',
-        (byte)'d',
-        (byte)'e',
-        (byte)'f',
-    };
-
     public string Hash(string input)
     {
         var encLen = (input.Length + 1) * 3;
         var enc = encLen <= 1024 ? stackalloc byte[encLen] : new byte[encLen];
-        Span<byte> bytes = stackalloc byte[HashBytesSize];
-        Span<char> res = stackalloc char[HashBytesSize * 2];
+        Span<byte> bytes = stackalloc byte[256 / 8];
 
         var len = Encoding.UTF8.GetBytes(input, enc);
         SHA256.HashData(enc[..len], bytes);
 
-        for (int i = 0, j = 0; i < HashBytesSize; ++i, ++j)
-        {
-            res[j] = (char)HexAlphabet[bytes[i] >> 4];
-            res[++j] = (char)HexAlphabet[bytes[i] & 0xF];
-        }
-
-        return new string(res);
+        return Convert.ToHexString(bytes);
     }
 }
+

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -9,10 +9,9 @@ public class Sha256HashService : IHashService
     public string Hash(string input)
     {
         byte[] toBeHashed = Encoding.UTF8.GetBytes(input);
-        using SHA256 sha256 = SHA256.Create();
-        byte[] bytes = sha256.ComputeHash(toBeHashed);
+        byte[] bytes = SHA256.HashData(toBeHashed);
 
-        StringBuilder strB = new();
+        StringBuilder strB = new(64);
         foreach (byte b in bytes)
         {
             strB.Append(b.ToString("x2"));

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -16,7 +16,7 @@ public class Sha256HashService : IHashService
         var len = Encoding.UTF8.GetBytes(input, enc);
         SHA256.HashData(enc[..len], bytes);
 
-        return Convert.ToHexString(bytes);
+        return Convert.ToHexString(bytes).ToLower();
     }
 }
 

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -10,8 +10,8 @@ public class Sha256HashService : IHashService
 
     public string Hash(string input)
     {
-        byte[] toBeHashed = Encoding.UTF8.GetBytes(input);
-        byte[] bytes = SHA256.HashData(toBeHashed);
+        var toBeHashed = Encoding.UTF8.GetBytes(input);
+        var bytes = SHA256.HashData(toBeHashed);
 
         var c = new char[bytes.Length * 2];
         for (int i = 0, j = 0; i < bytes.Length; ++i, ++j)

--- a/src/HonzaBotner.Services/Sha256HashService.cs
+++ b/src/HonzaBotner.Services/Sha256HashService.cs
@@ -7,26 +7,6 @@ namespace HonzaBotner.Services;
 
 public class Sha256HashService : IHashService
 {
-    private static ReadOnlySpan<byte> HexAlphabet => new []
-    {
-        (byte) '0',
-        (byte) '1',
-        (byte) '2',
-        (byte) '3',
-        (byte) '4',
-        (byte) '5',
-        (byte) '6',
-        (byte) '7',
-        (byte) '8',
-        (byte) '9',
-        (byte) 'a',
-        (byte) 'b',
-        (byte) 'c',
-        (byte) 'd',
-        (byte) 'e',
-        (byte) 'f',
-    };
-
     private const int HashBytesSize = 256 / 8;
 
     public string Hash(string input)
@@ -34,17 +14,10 @@ public class Sha256HashService : IHashService
         var encLen = Encoding.UTF8.GetMaxByteCount(input.Length);
         var enc = encLen <= 1024 ? stackalloc byte[encLen] : new byte[encLen];
         Span<byte> bytes = stackalloc byte[HashBytesSize];
-        Span<char> res = stackalloc char[HashBytesSize * 2];
 
         var len = Encoding.UTF8.GetBytes(input, enc);
         SHA256.HashData(enc[..len], bytes);
 
-        for (int i = 0, j = 0; i < HashBytesSize; ++i, ++j)
-        {
-            res[j] = (char) HexAlphabet[bytes[i] >> 4];
-            res[++j] = (char) HexAlphabet[bytes[i] & 0xF];
-        }
-
-        return new string(res);
+        return Convert.ToHexString(bytes);
     }
 }


### PR DESCRIPTION
Since .Net 5 there's a static method HashData. Creating a new instance together with `using` isn't needed anymore.

Also StringBuilder by default starts with capacity for 16 chars and increases it by the factor of 2 when required.
Setting the capacity to 64 will prevent 2 extra memory reallocations, thus making this code super duper fast.

I'm helping! 💪