### PR TITLE
Fix escaped mentions

### DIFF
--- a/src/HonzaBotner.Discord.Services/Commands/FunCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/FunCommands.cs
@@ -33,7 +33,7 @@ public class FunCommands : BaseCommandModule
         await ctx.TriggerTypingAsync();
 
         SecureRandom random = new();
-        string selected = choices[random.Next(choices.Length)].RemoveDiscordMentions(ctx.Guild, _logger);
+        string selected = choices[random.Next(choices.Length)].RemoveDiscordMentions(ctx.Guild);
 
         try
         {

--- a/src/HonzaBotner.Discord.Services/Commands/ReminderCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/ReminderCommands.cs
@@ -113,7 +113,6 @@ public class ReminderCommands : BaseCommandModule
             return;
         }
 
-        await context.TriggerTypingAsync();
         DiscordMessage message = await context.Channel.SendMessageAsync("Creating reminder...");
 
         Reminder reminder = await _service.CreateReminderAsync(

--- a/src/HonzaBotner.Discord.Services/Commands/WarningCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/WarningCommands.cs
@@ -113,7 +113,7 @@ public class WarningCommands : BaseCommandModule
             DiscordMember warningMember = await ctx.Guild.GetMemberAsync(warning.UserId);
             await ctx.Channel.SendMessageAsync(
                 $"**Varování {warning.Id}** pro uživatele **{warningMember.DisplayName}**:\n" +
-                $"{warning.Reason.RemoveDiscordMentions(ctx.Guild, _logger)}");
+                $"{warning.Reason.RemoveDiscordMentions(ctx.Guild)}");
             await ctx.Message.CreateReactionAsync(DiscordEmoji.FromName(ctx.Client, ":+1:"));
         }
         catch (Exception e)
@@ -170,7 +170,7 @@ public class WarningCommands : BaseCommandModule
                 else
                 {
                     await ctx.Channel.SendMessageAsync(
-                        $"**Varování (<@!{member.Id}>)**: {reason.RemoveDiscordMentions(ctx.Guild, _logger)}.");
+                        $"**Varování (<@!{member.Id}>)**: {reason.RemoveDiscordMentions(ctx.Guild)}.");
                 }
 
                 string messageForUser =
@@ -180,7 +180,7 @@ public class WarningCommands : BaseCommandModule
                     "\n\n" +
                     $"Toto je vaše **{numberOfWarnings}. varování**, #beGood.";
 
-                await member.SendMessageAsync(messageForUser.RemoveDiscordMentions(ctx.Guild, _logger));
+                await member.SendMessageAsync(messageForUser.RemoveDiscordMentions(ctx.Guild));
             }
             catch (Exception e)
             {

--- a/src/HonzaBotner.Discord.Services/Jobs/TriggerRemindersJobProvider.cs
+++ b/src/HonzaBotner.Discord.Services/Jobs/TriggerRemindersJobProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.Exceptions;
 using HonzaBotner.Discord.Managers;
+using HonzaBotner.Discord.Services.Extensions;
 using HonzaBotner.Discord.Services.Options;
 using HonzaBotner.Scheduler.Contract;
 using HonzaBotner.Services.Contract;
@@ -95,7 +96,8 @@ public class TriggerRemindersJobProvider : IJob
             }
 
             remindedUsers = remindedUsers.Remove(remindedUsers.Length - 2, 2);
-            remindedUsers.Append(" - nezapomeň" + (receivers.Count > 1 ? "te" : "") + " na `" + reminder.Content + "`");
+            remindedUsers.Append(" - nezapomeň" + (receivers.Count > 1 ? "te" : "") + " na "
+                                 + reminder.Content.RemoveDiscordMentions(channel.Guild));
 
             DiscordEmbed expiredEmbed = await _reminderManager.CreateExpiredReminderEmbedAsync(reminder);
 

--- a/src/HonzaBotner.Discord.Services/Managers/ReminderManager.cs
+++ b/src/HonzaBotner.Discord.Services/Managers/ReminderManager.cs
@@ -79,7 +79,7 @@ public class ReminderManager : IReminderManager
             .WithAuthor(
                 author?.DisplayName ?? "Unknown user",
                 iconUrl: author?.AvatarUrl)
-            .WithDescription(reminder.Content.RemoveDiscordMentions(guild, _logger) + datetime)
+            .WithDescription(reminder.Content.RemoveDiscordMentions(guild) + datetime)
             .WithColor(color);
 
         return embedBuilder.Build();


### PR DESCRIPTION
Fixes too broad mention definition and broken mention sanitizing under certain circumstances.

Identified mentions are now @​everyone, @​here, and <@​ID> where id has between 17 and 20 digits. It additionaly tries to recognize of which type is the mention - role or user, and tries to sanitize it correspondingly. On fail, it defaults to "dumb" sanitization used in @​everyone and @​here. That just adds zero width character behind @, so that user doesn't see any change to his precious message at first glance... Although if he tries to copy such message, I believe he might have hard time understanding why is the id invalid 😈 Poor guy... (no, not really 😈😈 We want to destroy any such mortals)

Additionaly fixes bug introduced by our new intern when rewriting reminder response, regarding to mention sanitization. That simpleton thought that surrounding response with `backslashes` would be enough!! So dumb right? Well it's fixed now, so let's not look deeper into who did it.

And yeah... I got rid of logging... Although controversial, some documented errors and edge cases from the library are covered, and the rest is serious enough that we want to propagate the issue (ServerErrorException, etc). It should be written now in such way that it counts with any common exception and the rest is propagated.