### PR TITLE
Fix exceptions thrown when attemping impossible pins

### DIFF
--- a/src/HonzaBotner.Discord.Services/EventHandlers/PinHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/PinHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
 using HonzaBotner.Discord.EventHandler;
 using HonzaBotner.Discord.Services.Options;
 using Microsoft.Extensions.Logging;
@@ -108,7 +109,13 @@ public class PinHandler : IEventHandler<MessageReactionAddEventArgs>
         // Fast heuristic to check if threshold is passed.
         if (reactions.Count >= _pinOptions.Threshold)
         {
-            await eventArgs.Message.PinAsync();
+            try
+            {
+                await eventArgs.Message.PinAsync();
+            }
+            catch (BadRequestException) // Message can not be pinned
+            {
+            }
             return EventHandlerResult.Continue;
         }
 
@@ -163,7 +170,13 @@ public class PinHandler : IEventHandler<MessageReactionAddEventArgs>
 
         if (score >= _pinOptions.Threshold)
         {
-            await eventArgs.Message.PinAsync();
+            try
+            {
+                await eventArgs.Message.PinAsync();
+            }
+            catch (BadRequestException) // Message can not be pinned
+            {
+            }
         }
 
         return EventHandlerResult.Continue;


### PR DESCRIPTION
Some messages are unpinnable, this prevents such exception from being elevated.