### PR TITLE
Added Ephemeral to response to warning modal timeout

### DIFF
--- a/src/HonzaBotner.Discord.Services/Commands/ModerationCommands.cs
+++ b/src/HonzaBotner.Discord.Services/Commands/ModerationCommands.cs
@@ -47,7 +47,7 @@ public class ModerationCommands : ApplicationCommandModule
         var modalReason = await interactivity.WaitForModalAsync(modalId, TimeSpan.FromMinutes(10));
         if (modalReason.TimedOut)
         {
-            await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Response timed out"));
+            await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Response timed out").AsEphemeral());
             return;
         }
 


### PR DESCRIPTION
Fixed this
![image](https://user-images.githubusercontent.com/39457484/193688587-58b61afa-eb3c-4f72-8650-6f6489a19e30.png)

Now it should be visible only for the moderator, who tried to issue the warning.