### PR TITLE
Allow opt-in ping in standup

### DIFF
--- a/src/HonzaBotner.Discord.Services/EventHandlers/StandupButtonHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/StandupButtonHandler.cs
@@ -47,18 +47,18 @@ public class StandupButtonHandler : IEventHandler<ComponentInteractionCreateEven
             if (target.Roles.Contains(standupPingRole))
             {
                 await target.RevokeRoleAsync(standupPingRole, "Doesn't want to be pinged anymore");
-                response.Append("Successfully removed ping role");
+                response.Append("🚫 Successfully removed ping role");
             }
             else
             {
                 await target.GrantRoleAsync(standupPingRole, "Wants to be pinged");
-                response.Append("Successfully added ping role");
+                response.Append("✅ Successfully added ping role");
             }
         }
         catch (DiscordException e)
         {
             _logger.LogWarning(e, "Failed while managing standup roles.");
-            response.Append("Error occured, please contact moderators");
+            response.Append("🤖 Error occured, please contact moderators");
         }
 
         await args.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,

--- a/src/HonzaBotner.Discord.Services/EventHandlers/StandupButtonHandler.cs
+++ b/src/HonzaBotner.Discord.Services/EventHandlers/StandupButtonHandler.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
+using HonzaBotner.Discord.EventHandler;
+using HonzaBotner.Discord.Services.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HonzaBotner.Discord.Services.EventHandlers;
+
+public class StandupButtonHandler : IEventHandler<ComponentInteractionCreateEventArgs>
+{
+
+    private readonly ButtonOptions _buttonOptions;
+    private readonly CommonCommandOptions _commandOptions;
+
+    private readonly ILogger<StandupButtonHandler> _logger;
+
+    public StandupButtonHandler(
+        IOptions<ButtonOptions> buttonOptions,
+        IOptions<CommonCommandOptions> commandOptions,
+        ILogger<StandupButtonHandler> logger)
+    {
+        _buttonOptions = buttonOptions.Value;
+        _commandOptions = commandOptions.Value;
+        _logger = logger;
+    }
+
+
+    public async Task<EventHandlerResult> Handle(ComponentInteractionCreateEventArgs args)
+    {
+        if (args.Id != _buttonOptions.StandupSwitchPingId)
+        {
+            return EventHandlerResult.Continue;
+        }
+
+        DiscordMember target = await args.Guild.GetMemberAsync(args.User.Id);
+        DiscordRole standupPingRole = args.Guild.GetRole(_commandOptions.StandUpRoleId);
+        StringBuilder response = new ();
+
+        try
+        {
+            if (target.Roles.Contains(standupPingRole))
+            {
+                await target.RevokeRoleAsync(standupPingRole, "Doesn't want to be pinged anymore");
+                response.Append("Successfully removed ping role");
+            }
+            else
+            {
+                await target.GrantRoleAsync(standupPingRole, "Wants to be pinged");
+                response.Append("Successfully added ping role");
+            }
+        }
+        catch (DiscordException e)
+        {
+            _logger.LogWarning(e, "Failed while managing standup roles.");
+            response.Append("Error occured, please contact moderators");
+        }
+
+        await args.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+            new DiscordInteractionResponseBuilder().WithContent(response.ToString()).AsEphemeral());
+
+        return EventHandlerResult.Stop;
+    }
+
+
+}

--- a/src/HonzaBotner.Discord.Services/Options/ButtonOptions.cs
+++ b/src/HonzaBotner.Discord.Services/Options/ButtonOptions.cs
@@ -7,5 +7,6 @@ public class ButtonOptions
     public string? VerificationId { get; set; }
     public string? StaffVerificationId { get; set; }
     public string? StaffRemoveRoleId { get; set; }
+    public string? StandupSwitchPingId { get; set; }
     public ulong[]? CzechChannelsIds { get; set; }
 }

--- a/src/HonzaBotner/Startup.cs
+++ b/src/HonzaBotner/Startup.cs
@@ -69,6 +69,7 @@ public class Startup
                         .AddEventHandler<VoiceHandler>()
                         .AddEventHandler<BadgeRoleHandler>()
                         .AddEventHandler<ThreadHandler>()
+                        .AddEventHandler<StandupButtonHandler>()
                         ;
                 }, commands =>
                 {

--- a/src/HonzaBotner/appsettings.BotDev.json
+++ b/src/HonzaBotner/appsettings.BotDev.json
@@ -58,7 +58,8 @@
     "ButtonOptions": {
         "VerificationId": "verification-user",
         "StaffVerificationId": "verification-staff",
-        "StaffRemoveRoleId": "verification-remove-staff"
+        "StaffRemoveRoleId": "verification-remove-staff",
+        "StandupSwitchPingId": "standup-ping-role-switch"
     },
     "BadgeRoleOptions": {
         "TriggerRoles": [

--- a/src/HonzaBotner/appsettings.CvutFit.json
+++ b/src/HonzaBotner/appsettings.CvutFit.json
@@ -28,7 +28,7 @@
             691998530151120936,
             774247506669600798
         ],
-        "StandUpRoleId": 972019490818768927,
+        "StandUpRoleId": 1044398883414999061,
         "StandUpChannelId": 972019138446897162
     },
     "CustomVoiceOptions": {
@@ -97,6 +97,7 @@
         "VerificationId": "verification-user",
         "StaffVerificationId": "verification-staff",
         "StaffRemoveRoleId": "verification-remove-staff",
+        "StandupSwitchPingId": "standup-ping-role-switch",
         "CzechChannelsIds": [507515506073403402]
     },
     "BadgeRoleOptions": {

--- a/src/HonzaBotner/appsettings.Development.json
+++ b/src/HonzaBotner/appsettings.Development.json
@@ -65,6 +65,7 @@
         "VerificationId": "verification-user",
         "StaffVerificationId": "verification-staff",
         "StaffRemoveRoleId": "verification-remove-staff",
+        "StandupSwitchPingId": "standup-ping-role-switch",
         "CzechChannelsIds": [750108543125946448]
     },
     "BadgeRoleOptions": {


### PR DESCRIPTION
Allow people to opt into ping in standup, status messages will be sent with opt in/out button.

![image](https://user-images.githubusercontent.com/29132060/203182466-8f8d48dc-aca1-4004-b98c-26f5f4abe462.png)


(No, "here" is not the part that pings, actually the ping is hidden in spoiler. It just doesn't look nice to address only "standup ping" people in the message)

New role was created. Old Standup role serves to access the channel, new role is only for the ping. Called Standup ping on main server, might be renamed...

@LucyAnne98