### PR TITLE
Standup: Ignore days with no activity

### DIFF
--- a/src/HonzaBotner.Discord.Services/Jobs/StandUpJobProvider.cs
+++ b/src/HonzaBotner.Discord.Services/Jobs/StandUpJobProvider.cs
@@ -100,6 +100,11 @@ public class StandUpJobProvider : IJob
                 }
             }
 
+            if(ok.Add(fail).Sum == 0)
+            {
+                return;
+            }
+            
             DiscordRole standupPingRole = channel.Guild.GetRole(_commonOptions.StandUpRoleId);
 
             var content = new DiscordMessageBuilder()


### PR DESCRIPTION
Currently, Honza Botner sends a daily summary message to #standup even when the previous day had no activity from the users whatsoever, so sometimes it can happen that the bot is the only one sending messages to the channel for several days in a row. This tiny change prevents sending these summaries whenever there is nothing to be summarized.